### PR TITLE
Unify Raw Datasource Access

### DIFF
--- a/src/fixpoint/core.clj
+++ b/src/fixpoint/core.clj
@@ -23,7 +23,12 @@
      `:id` (the reference ID),  `:data` (the actual data inserted) and
      optionally `:tags` (a seq of tags for entity filtering).
 
-     Reference IDs __must__ be namespaced keywords."))
+     Reference IDs __must__ be namespaced keywords.")
+  (as-raw-datasource [this]
+    "Retrieve the underlying raw datasource, e.g. a `clojure.java.jdbc` database
+     spec, or some raw connection object.
+
+     This should fail on non-started datasources."))
 
 (defprotocol Fixture
   "Protocol for datasource fixtures."
@@ -68,6 +73,15 @@
   (let [ds (maybe-datasource id)]
     (assert ds (format "no datasource registered as: %s" (pr-str id)))
     ds))
+
+(defn raw-datasource
+  "Get the raw datasource value for the [[Datasource]] registered under the
+   given ID within the current scope.
+
+   See [[datasource]] and [[as-raw-datasource]]."
+  [id]
+  (-> (datasource id)
+      (as-raw-datasource)))
 
 ;; ## Rollback
 

--- a/src/fixpoint/datasource/elastic.clj
+++ b/src/fixpoint/datasource/elastic.clj
@@ -215,7 +215,9 @@
   (insert-document! [this {:keys [elastic/mapping] :as document}]
     (cond (false? mapping) (handle-declare-index! this document)
           mapping          (handle-create-index! this document)
-          :else            (handle-put! this document))))
+          :else            (handle-put! this document)))
+  (as-raw-datasource [_]
+    client))
 
 (defn make-datasource
   "Create an ElasticSearch datasource. Rollback capability is achieved by
@@ -257,13 +259,6 @@
      :id    id}))
 
 ;; ## Helpers
-
-(defmacro with-elastic-client
-  "Run the given body in the context of the spandex ES client belonging
-   to the given datasource."
-  [[sym datasource-id] & body]
-  `(let [~sym (:client (fix/datasource ~datasource-id))]
-     ~@body))
 
 (defn index
   "Retrieve the actual name of the index that was declared using `index-key`

--- a/src/fixpoint/datasource/hikari.clj
+++ b/src/fixpoint/datasource/hikari.clj
@@ -54,10 +54,8 @@
          (fix/run-with-rollback datasource)))
   (insert-document! [_ document]
     (fix/insert-document! datasource document))
-
-  fix-jdbc/JDBCDatasource
-  (as-jdbc-datasource [_]
-    (fix-jdbc/as-jdbc-datasource datasource)))
+  (as-raw-datasource [_]
+    (fix/raw-datasource datasource)))
 
 (defn wrap-jdbc-datasource
   "Wrap the given [[JDBCDatasource]] to use a Hikari connection pool."

--- a/src/fixpoint/datasource/jdbc.clj
+++ b/src/fixpoint/datasource/jdbc.clj
@@ -48,18 +48,20 @@
 
 (defprotocol JDBCDatasource
   "Protocol for JDBC datasources."
-  (as-jdbc-datasource [_]
-    "Retrive a JDBC Datasource object to be directly usable for queries."))
-
-(defmacro with-jdbc-datasource
-  "Look up a JDBC datasource using its ID, bind it to `sym` and run the body."
-  [[sym datasource-id] & body]
-  `(let [~sym (as-jdbc-datasource (fix/datasource ~datasource-id))]
-     ~@body))
+  (get-db-spec [this]
+    "Retrieve the JDBC datasource's database spec.")
+  (set-db-spec [this new-db-spec]
+    "Set the JDBC datasource's database spec."))
 
 ;; ## Datasource
 
 (defrecord Database [id db pre-fn post-fn]
+  JDBCDatasource
+  (get-db-spec [_]
+    db)
+  (set-db-spec [this new-db-spec]
+    (assoc this :db new-db-spec))
+
   fix/Datasource
   (datasource-id [_]
     id)
@@ -71,9 +73,7 @@
     (run-with-transaction-rollback this f))
   (insert-document! [this document]
     (insert! this document))
-
-  JDBCDatasource
-  (as-jdbc-datasource [_]
+  (as-raw-datasource [_]
     db))
 
 (defn make-datasource

--- a/test/fixpoint/datasource/hikari_test.clj
+++ b/test/fixpoint/datasource/hikari_test.clj
@@ -3,7 +3,6 @@
             [clojure.java.jdbc :as jdbc]
             [fixpoint.datasource
              [hikari :as hikari]
-             [jdbc :refer [with-jdbc-datasource]]
              [postgresql :as pg]]
             [fixpoint.core :as fix]))
 
@@ -45,7 +44,7 @@
 (defn- use-postgresql-setup
   []
   (fn [f]
-    (with-jdbc-datasource [db :test-db]
+    (let [db (fix/raw-datasource :test-db)]
       (->> (str "create table people ("
                 "  id         SERIAL PRIMARY KEY,"
                 "  name       VARCHAR NOT NULL,"
@@ -87,8 +86,8 @@
          :post/question :person/me))
 
   (testing "datasource access."
-    (with-jdbc-datasource [db :test-db]
-      (let [ids (->> ["select id from people order by name asc"]
-                     (jdbc/query db)
-                     (map :id))]
-        (is (= (fix/ids [:person/me :person/you]) ids))))))
+    (let [db (fix/raw-datasource :test-db)
+          ids (->> ["select id from people order by name asc"]
+                   (jdbc/query db)
+                   (map :id))]
+      (is (= (fix/ids [:person/me :person/you]) ids)))))

--- a/test/fixpoint/datasource/mysql_test.clj
+++ b/test/fixpoint/datasource/mysql_test.clj
@@ -1,9 +1,7 @@
 (ns ^:mysql fixpoint.datasource.mysql-test
   (:require [clojure.test :refer :all]
             [clojure.java.jdbc :as jdbc]
-            [fixpoint.datasource
-             [jdbc :refer [with-jdbc-datasource]]
-             [mysql :as mysql]]
+            [fixpoint.datasource.mysql :as mysql]
             [fixpoint.core :as fix]))
 
 ;; ## Test Datasource
@@ -43,7 +41,7 @@
 (defn- use-mysql-setup
   []
   (fn [f]
-    (with-jdbc-datasource [db :test-db]
+    (let [db (fix/raw-datasource :test-db)]
       (try
         (->> (str "create table people ("
                   "  id         INT AUTO_INCREMENT PRIMARY KEY,"
@@ -89,8 +87,8 @@
          :post/question :person/me))
 
   (testing "datasource access."
-    (with-jdbc-datasource [db :test-db]
-      (let [ids (->> ["select id from people order by name asc"]
-                     (jdbc/query db)
-                     (map :id))]
-        (is (= (fix/ids [:person/me :person/you]) ids))))))
+    (let [db (fix/raw-datasource :test-db)
+          ids (->> ["select id from people order by name asc"]
+                   (jdbc/query db)
+                   (map :id))]
+      (is (= (fix/ids [:person/me :person/you]) ids)))))

--- a/test/fixpoint/datasource/postgresql_test.clj
+++ b/test/fixpoint/datasource/postgresql_test.clj
@@ -1,9 +1,7 @@
 (ns ^:postgresql fixpoint.datasource.postgresql-test
   (:require [clojure.test :refer :all]
             [clojure.java.jdbc :as jdbc]
-            [fixpoint.datasource
-             [jdbc :refer [with-jdbc-datasource]]
-             [postgresql :as pg]]
+            [fixpoint.datasource.postgresql :as pg]
             [fixpoint.core :as fix]))
 
 ;; ## Test Datasource
@@ -43,7 +41,7 @@
 (defn- use-postgresql-setup
   []
   (fn [f]
-    (with-jdbc-datasource [db :test-db]
+    (let [db (fix/raw-datasource :test-db)]
       (->> (str "create table people ("
                 "  id         SERIAL PRIMARY KEY,"
                 "  name       VARCHAR NOT NULL,"
@@ -85,8 +83,8 @@
          :post/question :person/me))
 
   (testing "datasource access."
-    (with-jdbc-datasource [db :test-db]
-      (let [ids (->> ["select id from people order by name asc"]
-                     (jdbc/query db)
-                     (map :id))]
-        (is (= (fix/ids [:person/me :person/you]) ids))))))
+    (let [db (fix/raw-datasource :test-db)
+          ids (->> ["select id from people order by name asc"]
+                   (jdbc/query db)
+                   (map :id))]
+      (is (= (fix/ids [:person/me :person/you]) ids)))))


### PR DESCRIPTION
Currently, there are macros for accessing the raw client/connection/pool objects:

- `with-jdbc-datasource`
- `with-elastic-client`

This PR introduces `as-raw-datasource` (to be implemented by datasources) and `raw-datasource` (performing a lookup in the current scope), adding a unified way of getting a handle on the underlying objects.