### PR TITLE
Explicit Primary Keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_script:
 env:
   global:
     - FIXPOINT_POSTGRESQL_URI="jdbc:postgresql://localhost:5432/fix_test?user=postgres&password="
-    - FIXPOINT_MYSQL_URI="jdbc:mysql://localhost:3306/fix_test?user=travis&password="
+    - FIXPOINT_MYSQL_URI="jdbc:mysql://localhost:3306/fix_test?user=travis&password=&useSSL=false"
     - FIXPOINT_ELASTIC_HOST="http://localhost:9200"

--- a/src/fixpoint/datasource/mysql.clj
+++ b/src/fixpoint/datasource/mysql.clj
@@ -26,15 +26,16 @@
 (defn- query-inserted-row
   [db
    {:keys [db/table db/primary-key]
-    :or {db/primary-key :id}}
+    :or {db/primary-key :id}
+    :as document}
    {:keys [generated_key]}]
-  (when generated_key
+  (when-let [document-id (or generated_key (get document primary-key))]
     (let [table-name (csk/->snake_case_string table)
           column     (csk/->snake_case_string primary-key)
           [row] (->> [(format "select * from %s where %s = ? limit 1"
                               table-name
                               column)
-                      generated_key]
+                      document-id]
                      (jdbc/query db))]
       (verify-inserted-row! table-name column document-id row)
       row)))

--- a/test/fixpoint/datasource/mysql_test.clj
+++ b/test/fixpoint/datasource/mysql_test.clj
@@ -10,7 +10,7 @@
   (mysql/make-datasource
     :test-db
     {:connection-uri (or (System/getenv "FIXPOINT_MYSQL_URI")
-                         "jdbc:mysql://localhost:3306/test")}))
+                         "jdbc:mysql://localhost:3306/test?useSSL=false")}))
 
 ;; ## Fixtures
 

--- a/test/fixpoint/datasource/mysql_test.clj
+++ b/test/fixpoint/datasource/mysql_test.clj
@@ -31,12 +31,23 @@
       (fix/as reference)
       (fix/on-datasource :test-db)))
 
+(defn- post-with-explicit-id
+  [reference id person-reference text]
+  (-> {:db/table  :posts
+       :id        id
+       :text      text
+       :author-id person-reference}
+      (fix/as reference)
+      (fix/on-datasource :test-db)))
+
+(def +explicit-post-id+ 123456789)
+
 (def +fixtures+
   [(person :person/me     "me"        27)
    (person :person/you    "you"       29)
    (post   :post/happy    :person/me  "Awesome.")
-   (post   :post/meh      :person/you "Meh.")
-   (post   :post/question [:post/happy :author-id] "Do you really think so?")])
+   (post   :post/question [:post/happy :author-id] "Do you really think so?")
+   (post-with-explicit-id :post/meh +explicit-post-id+ :person/you "Meh.")])
 
 (defn- use-mysql-setup
   []
@@ -85,6 +96,9 @@
          :post/happy    :person/me
          :post/meh      :person/you
          :post/question :person/me))
+
+  (testing "explicitly set primary key."
+    (is (= +explicit-post-id+ (fix/id :post/meh))))
 
   (testing "datasource access."
     (let [db (fix/raw-datasource :test-db)


### PR DESCRIPTION
This patch fixes the handling of explicitly set primary keys in the MySQL datasource. Previously, it only relied on `generated_key` (which is not given if the key was, well, not generated), now it takes either `generated_key` or whatever corresponds to `:db/primary-key) in the original document.