### PR TITLE
Embedded AMQP 0.9.1 Broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+derby.log

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ test datastores and data.
 [![Clojars Artifact](https://img.shields.io/clojars/v/stylefruits/fixpoint.svg)](https://clojars.org/stylefruits/fixpoint)
 
 Ready-to-use components for [PostgreSQL][postgres], [MySQL][mysql] and
-[ElasticSearch][elastic] are already included.
+[ElasticSearch][elastic], as well as an [AMQP Broker][qpid] are already included.
 
 [postgres]: https://www.postgresql.org/
 [mysql]: https://www.mysql.com/
 [elastic]: https://www.elastic.co/products/elasticsearch
+[qpid]: https://qpid.apache.org/
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,13 @@
           [org.postgresql/postgresql "9.4.1212"]
           [mysql/mysql-connector-java "5.1.41"]
           [cc.qbits/spandex "0.3.4"
-           :exclusions [org.clojure/clojure]]]}
-   :codox {:dependencies [[org.clojure/tools.reader "1.0.0-beta4"]
-                          [codox-theme-rdash "0.1.1"]]
+           :exclusions [org.clojure/clojure]]
+          [org.apache.qpid/qpid-broker "6.1.3"
+           :exclusions [org.webjars.bower/dstore
+                        org.slf4j/slf4j-api]]
+          [kithara "0.1.8"]]}
+   :codox {:dependencies [[org.clojure/tools.reader "1.0.0"]
+                          [codox-theme-rdash "0.1.2"]]
            :plugins [[lein-codox "0.10.3"]]
            :codox {:project {:name "fixpoint"}
                    :metadata {:doc/format :markdown}

--- a/resources/fixpoint/amqp/broker-config.json
+++ b/resources/fixpoint/amqp/broker-config.json
@@ -1,0 +1,49 @@
+{
+  "name": "${broker.name}",
+  "modelVersion": "6.0",
+  "authenticationproviders" : [ {
+    "name" : "plain",
+    "type" : "Plain",
+    "secureOnlyMechanisms": [],
+    "users" : [ {
+      "name" : "${fixpoint.username}",
+      "type" : "managed",
+      "password" : "${fixpoint.password}"
+    } ]
+  } ],
+  "brokerloggers" : [ {
+    "name" : "stdout",
+    "type" : "Console",
+    "brokerloginclusionrules" : [ {
+      "name" : "Root",
+      "type" : "NameAndLevel",
+      "level" : "WARN",
+      "loggerName" : "ROOT"
+    }, {
+      "name" : "Qpid",
+      "type" : "NameAndLevel",
+      "level" : "${fixpoint.log_level}",
+      "loggerName" : "org.apache.qpid.*"
+    }, {
+      "name" : "Operational",
+      "type" : "NameAndLevel",
+      "level" : "${fixpoint.log_level}",
+      "loggerName" : "qpid.message.*"
+    } ]
+  } ],
+  "ports" : [  {
+    "name" : "AMQP",
+    "port" : "${qpid.amqp_port}",
+    "authenticationProvider" : "plain",
+    "virtualhostaliases": [ {
+      "name": "${fixpoint.vhost}",
+      "type": "nameAlias"
+    } ]
+  } ],
+  "virtualhostnodes": [ {
+    "name": "${fixpoint.vhost}",
+    "type": "JSON",
+    "defaultVirtualHostNode": true,
+    "virtualHostInitialConfiguration": "${qpid.initial_config_virtualhost_config}"
+  } ]
+}

--- a/src/fixpoint/datasource/amqp.clj
+++ b/src/fixpoint/datasource/amqp.clj
@@ -1,0 +1,119 @@
+(ns fixpoint.datasource.amqp
+  "An AMQP broker datasource compatible with AMQP 0.9.1.
+
+   Make sure the `org.apache.qpid/qpid-broker` dependency is available on your
+   classpath."
+  (:require [fixpoint.datasource.file-utils :as f]
+            [fixpoint.core :as fix]
+            [clojure.java.io :as io])
+  (:import [org.apache.qpid.server Broker BrokerOptions]))
+
+;; ## Helper
+
+(defmacro ^:private let-cleanup
+  [[sym start-fn stop-fn & more] & body]
+  (if (seq more)
+    `(let-cleanup [~sym ~start-fn ~stop-fn]
+       (let-cleanup [~@more]
+         ~@body))
+    `(let [val# ~start-fn
+           ~sym val#]
+       (try
+         (do ~@body)
+         (catch Throwable t#
+           (~stop-fn val#)
+           (throw t#))))))
+
+;; ## Metadata
+
+(def ^:private default-configuration-file
+  (io/resource "fixpoint/amqp/broker-config.json"))
+
+(defn- random-string
+  []
+  (str (java.util.UUID/randomUUID)))
+
+(defn- prepare-broker-data
+  [{:keys [log-level port configuration-file username password vhost]}]
+  {:workdir   (f/create-temporary-directory!)
+   :port      (or port 57622)
+   :log-level (or log-level :error)
+   :username  (or username (random-string))
+   :password  (or password (random-string))
+   :vhost     (or vhost "default")
+   :config    (or configuration-file default-configuration-file)})
+
+(defn- cleanup-broker-data
+  [{:keys [workdir]}]
+  (f/delete-directory-recursively! workdir)
+  nil)
+
+;; ## Broker Logic
+
+(defn- prop
+  [^BrokerOptions options k v]
+  (.setConfigProperty options (name k) (str v)))
+
+(defn- start-broker!
+  [{:keys [config log-level port username password vhost workdir]}]
+  (let [options (doto (BrokerOptions.)
+                  (prop :broker.name        "fixpoint-embedded-amqp")
+                  (prop :qpid.amqp_port     port)
+                  (prop :qpid.http_port     (inc port))
+                  (prop :qpid.work_dir      (f/path->string workdir))
+                  (prop :fixpoint.log_level (-> log-level name (.toUpperCase)))
+                  (prop :fixpoint.username  username)
+                  (prop :fixpoint.password  password)
+                  (prop :fixpoint.vhost     vhost)
+                  (.setInitialConfigurationLocation (str config)))]
+    (doto (Broker.)
+      (.startup options))))
+
+(defn- stop-broker!
+  [^Broker broker]
+  (.shutdown broker))
+
+;; ## Datasource
+
+(defrecord AmqpDatasource [id options metadata broker]
+  fix/Datasource
+  (datasource-id [this]
+    id)
+  (start-datasource [this]
+    (let-cleanup [metadata (prepare-broker-data options) cleanup-broker-data
+                  broker   (start-broker! metadata) stop-broker!]
+      (assoc this
+             :broker   broker
+             :metadata metadata)))
+  (stop-datasource [this]
+    (stop-broker! broker)
+    (cleanup-broker-data metadata)
+    (assoc this :metadata nil, :broker nil))
+  (run-with-rollback [this f]
+    (f this))
+  (insert-document! [this document]
+    (throw
+      (IllegalArgumentException.
+        "AmqpDatasource does not accept any documents.")))
+  (as-raw-datasource [_]
+    (-> metadata
+        (select-keys [:port :username :password :vhost])
+        (update :vhost #(str "/" %)))))
+
+(defn make-datasource
+  "Create a datasource corresponding to an AMQP 0.9.1 broker. Options include:
+
+   - `:port`: the port to run the broker on (default: 57622),
+   - `log-level`: the broker's log level (`:debug`, `:info`, `:warn`, `:error`),
+   - `:username`: the username for authentication (default: random),
+   - `:password`: the password for authentication (default: random),
+   - `:vhost`: the name of the default vhost to create (default: \"default\").
+
+   This datasource doesn't accept any documents, it just sets up an AMQP broker
+   and exposes the port, vhost and credentials using [[raw-datasource]]."
+  ([id]
+   (make-datasource id {}))
+  ([id options]
+   (map->AmqpDatasource
+     {:id      id
+      :options options})))

--- a/src/fixpoint/datasource/file_utils.clj
+++ b/src/fixpoint/datasource/file_utils.clj
@@ -1,0 +1,28 @@
+(ns fixpoint.datasource.file-utils
+  (:import [java.nio.file Files Path SimpleFileVisitor FileVisitResult]
+           [java.nio.file.attribute FileAttribute]))
+
+;; ## Directory Handling
+
+(let [empty-array (into-array FileAttribute [])]
+  (defn create-temporary-directory!
+    ^Path []
+    (Files/createTempDirectory "fixpoint-embedded-amqp" empty-array)))
+
+(let [delete-visitor (proxy [SimpleFileVisitor] []
+                       (visitFile [file _]
+                         (Files/delete file)
+                         FileVisitResult/CONTINUE)
+                       (postVisitDirectory [directory exception]
+                         (when-not exception
+                           (Files/delete directory))
+                         FileVisitResult/CONTINUE))]
+  (defn delete-directory-recursively!
+    [^Path directory]
+    (Files/walkFileTree directory delete-visitor)))
+
+(defn path->string
+  [^Path path]
+  (-> path
+      (.toAbsolutePath)
+      (str)))

--- a/test/fixpoint/datasource/amqp_test.clj
+++ b/test/fixpoint/datasource/amqp_test.clj
@@ -1,0 +1,67 @@
+(ns fixpoint.datasource.amqp-test
+  (:require [clojure.test :refer :all]
+            [kithara.rabbitmq
+             [channel :as rch]
+             [connection :as rc]
+             [exchange :as re]
+             [queue :as rq]
+             [publish :refer [publish]]]
+            [fixpoint.datasource.amqp :as amqp]
+            [fixpoint.core :as fix]))
+
+;; ## Test Datasource
+
+(def test-amqp
+  (amqp/make-datasource :amqp {:log-level :error}))
+
+;; ## Fixtures
+
+(use-fixtures
+  :once
+  (fix/use-datasources test-amqp))
+
+;; ## Helpers
+
+(defmacro with-connection
+  [[sym options] & body]
+  `(let [connection# (rc/open ~options)
+         ~sym connection#]
+     (try
+       (do ~@body)
+       (finally
+         (rc/close connection#)))))
+
+(defn- setup-amqp!
+  [connection]
+  (let [ch (is (rch/open connection))
+        ex (is (re/declare ch "test-exchange" :topic))
+        qa (is (rq/declare ch "test-queue-a"))
+        qb (is (rq/declare ch "test-queue-b"))]
+    (rq/bind qa {:exchange "test-exchange", :routing-keys ["a"]})
+    (rq/bind qb {:exchange "test-exchange", :routing-keys ["b" "a"]})
+    {:channel ch :qa qa :qb qb}))
+
+(defn- publish-message!
+  [channel routing-key]
+  (->> {:exchange "test-exchange"
+        :routing-key routing-key
+        :body        (.getBytes routing-key "UTF-8")}
+       (publish channel))
+  true)
+
+(defn- get-messages!
+  [q]
+  (->> #(rq/get q {:auto-ack? true, :as :string})
+       (repeatedly 2)
+       (mapv (juxt :routing-key :body))))
+
+;; ## Tests
+
+(deftest t-amqp
+  (with-connection [connection (is (fix/raw-datasource :amqp))]
+    (let [{:keys [channel qa qb]} (setup-amqp! connection)]
+      (is (publish-message! channel "a"))
+      (is (publish-message! channel "b"))
+      (is (publish-message! channel "c"))
+      (is (= [["a" "a"] [nil nil]] (get-messages! qa)))
+      (is (= [["a" "a"] ["b" "b"]] (get-messages! qb))))))


### PR DESCRIPTION
This adds a fixpoint datasource representing an embedded AMQP 0.9.1 broker, based on [Apache Qpid][qpid]. This can be used to write unit-tests for AMQP-based event emitters and consumers.

[qpid]: https://qpid.apache.org/